### PR TITLE
Integrate Google Analytics and configure production baseUrl

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "build": "NODE_ENV=production webpack --mode production --colors --optimize-minimize",
     "start": "NODE_ENV=development nodemon --exec npm run watch --watch src/content.js",
+    "start:ga": "GOOGLE_ANALYTICS=on npm run start",
     "test": "node scripts/validate-html.js",
     "watch": "webpack-dev-server --watch --colors -d"
   },

--- a/src/layouts/base.hbs
+++ b/src/layouts/base.hbs
@@ -35,6 +35,18 @@
   <script src="assets/js/jquery.easing.min.js"></script>
   <script src="assets/js/aos.js"></script>
   <script src="assets/js/jquery.sticky.js"></script>
+
+  {{#if htmlWebpackPlugin.options.isAnalyticsActive }}
+    {{!-- Global site tag (gtag.js) - Google Analytics --}}
+    <script async src="https://www.googletagmanager.com/gtag/js?id={{ htmlWebpackPlugin.options.gaKey }}"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag() { dataLayer.push(arguments); }
+      gtag("js", new Date());
+      gtag("config", "{{ htmlWebpackPlugin.options.gaKey }}");
+    </script>
+  {{/if}}
+
 </body>
 
 </html>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -10,19 +10,33 @@ const ip = require("ip");
 
 const pages = require("./src/content");
 
-// TODO: configure production properly
-const ipAddr = ip.address();
+const GA_KEY_STAGING = "UA-151413843-3";
+const GA_KEY_PRODUCTION = "UA-151413843-4";
+const gaKey = process.env.NODE_ENV === "development" ? GA_KEY_STAGING : GA_KEY_PRODUCTION;
+const isAnalyticsActive = process.env.NODE_ENV === "production" || process.env.GOOGLE_ANALYTICS === 'on';
+
 const proxy = "http://localhost:8081/";
-const port = process.env.NODE_ENV === "development" ? 3001 : "";
 let baseUrl = proxy;
 
-if (ipAddr) {
-  baseUrl = port ? `http://${ipAddr}:${port}/` : `https://${ipAddr}/`;
+if (process.env.NODE_ENV === 'development') {
+  const ipAddr = ip.address();
+  const port = process.env.NODE_ENV === "development" ? 3001 : "";
+
+  if (ipAddr) {
+    baseUrl = port ? `http://${ipAddr}:${port}/` : `https://${ipAddr}/`;
+  }
+} else if (process.env.NODE_ENV === 'production') {
+  baseUrl = "https://tweak-extension.com/"
 }
 
 const common = {
-  baseUrl
+  baseUrl,
+  gaKey,
+  isAnalyticsActive
 };
+
+console.info("Running with the common configurations:", common);
+
 const renderedPages = pages.map(
   page =>
     new HtmlWebpackPlugin({


### PR DESCRIPTION
- Add GA (staging and production)
- To run site with GA locally use `npm run start:ga`
- Configure production `baseUrl` to point to [https://tweak-extension.com/](https://tweak-extension.com/)